### PR TITLE
10.0 [ADD] Add a domain to avoid displaying already mapped product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.idea

--- a/connector_lengow/__manifest__.py
+++ b/connector_lengow/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Lengow Connector",
     "summary": "Module used to connect Odoo to Lengow",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Connector",
     "website": "https://odoo-community.org/",
     "author": "Cédric Pigeon, ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/connector_lengow/tests/test_lengow_product_binding_wizard.py
+++ b/connector_lengow/tests/test_lengow_product_binding_wizard.py
@@ -125,3 +125,31 @@ class TestLengowProductBinding(common.SetUpLengowBase20):
              ('lengow_id', '=', self.product.default_code)])
 
         self.assertEqual(len(bind_record), 0)
+
+    def test_onchange_catalogue_id(self):
+        """
+        Test for the onchange function _onchange_catalogue_id().
+        This function just have to return a domain to exclude product already
+        into the catalogue.
+        :return: bool
+        """
+        bind_wizard_model = self.bind_wizard_model
+        catalogue = self.catalogue
+        product_obj = self.env['product.product']
+        current_products = catalogue.binded_product_ids.mapped("odoo_id")
+        values = {
+            'catalogue_id': catalogue.id,
+        }
+        wizard = bind_wizard_model.create(values)
+        onchange = wizard._onchange_catalogue_id()
+        domains = onchange.get('domain', {})
+        product_domain = domains.get('product_ids', None)
+        current_products_ids = current_products.ids
+        # We should have a returned domain as a list
+        self.assertIsInstance(product_domain, list)
+        products_available = product_obj.search(product_domain)
+        # Every products found should NOT be into the list of
+        # product already into the catalogue
+        for product_available in products_available:
+            self.assertNotIn(product_available.id, current_products_ids)
+        return True

--- a/connector_lengow/wizards/lengow_product_binding_wizard.py
+++ b/connector_lengow/wizards/lengow_product_binding_wizard.py
@@ -24,6 +24,29 @@ class LengowProductBindingWizard(models.TransientModel):
             res['catalogue_id'] = catalogue_id
         return res
 
+    @api.onchange("catalogue_id")
+    def _onchange_catalogue_id(self):
+        """
+        Onchange function for the catalogue_id field.
+        This function add a domain on product_ids fields depending on the
+        catalogue_id, to avoid displaying already mapped products.
+        :return: dict
+        """
+        domain_dict = {}
+        if self.catalogue_id:
+            # Get every product.product already mapped
+            products = self.catalogue_id.binded_product_ids.mapped("odoo_id")
+            domain = [
+                ('id', 'not in', products.ids),
+            ]
+            domain_dict.update({
+                'product_ids': domain,
+            })
+        result = {
+            'domain': domain_dict,
+        }
+        return result
+
     @api.multi
     def bind_products(self):
         for wizard in self:


### PR DESCRIPTION
On the catalogue, into the wizard to add some products into this catalogue: do not display product.product already into the current catalogue.
Could be confusing for a user.